### PR TITLE
fix: error in cart.js with unexisting service

### DIFF
--- a/cart/cart.js
+++ b/cart/cart.js
@@ -29,7 +29,7 @@ const EventSourcedEntity = as.EventSourcedEntity;
  */
 const entity = new EventSourcedEntity(
   ['cart.proto', 'domain.proto'],
-  'ecommerce.CartService',
+  'com.example.shoppingcart.CartService',
   'cart',
   {
     // A snapshot will be persisted every time this many events are emitted.

--- a/cart/package-lock.json
+++ b/cart/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ecommerce-cart",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ecommerce-cart",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.5.5",


### PR DESCRIPTION
Fixes https://github.com/lightbend/akkaserverless/issues/4364

The `cart.js` file still used an "old" Protobuf package name, this PR solves that problem.